### PR TITLE
Serializers based on RedisValue

### DIFF
--- a/src/CachingFramework.Redis.MsgPack/MsgPackSerializer.cs
+++ b/src/CachingFramework.Redis.MsgPack/MsgPackSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using MsgPack.Serialization;
+using StackExchange.Redis;
 
 namespace CachingFramework.Redis.MsgPack
 {
@@ -15,11 +16,11 @@ namespace CachingFramework.Redis.MsgPack
         /// <typeparam name="T"></typeparam>
         /// <param name="value">The value.</param>
         /// <returns>System.Byte[].</returns>
-        public byte[] Serialize<T>(T value)
+        public RedisValue Serialize<T>(T value)
         {
             if (value == null)
             {
-                return null;
+                return RedisValue.Null;
             }
             var serializer = SerializationContext.Default.GetSerializer(value.GetType());
             using (var stream = new MemoryStream())
@@ -35,9 +36,9 @@ namespace CachingFramework.Redis.MsgPack
         /// <typeparam name="T"></typeparam>
         /// <param name="value">The value.</param>
         /// <returns>T.</returns>
-        public T Deserialize<T>(byte[] value)
+        public T Deserialize<T>(RedisValue value)
         {
-            if (value == null)
+            if (value.IsNull)
             {
                 return default(T);
             }

--- a/src/CachingFramework.Redis/Contracts/ISerializer.cs
+++ b/src/CachingFramework.Redis/Contracts/ISerializer.cs
@@ -1,4 +1,6 @@
-﻿namespace CachingFramework.Redis.Contracts
+﻿using StackExchange.Redis;
+
+namespace CachingFramework.Redis.Contracts
 {
     /// <summary>
     /// Interface that defines serialization/deserialization generic methods to be used by the cache engine
@@ -11,12 +13,12 @@
         /// <typeparam name="T"></typeparam>
         /// <param name="value">The value.</param>
         /// <returns>System.String.</returns>
-        byte[] Serialize<T>(T value);
+        RedisValue Serialize<T>(T value);
         /// <summary>
         /// Deserializes the specified value.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="value">The value.</param>
-        T Deserialize<T>(byte[] value);
+        T Deserialize<T>(RedisValue value);
     }
 }

--- a/src/CachingFramework.Redis/Serializers/BinarySerializer.cs
+++ b/src/CachingFramework.Redis/Serializers/BinarySerializer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using CachingFramework.Redis.Contracts;
 using System.Runtime.Serialization.Formatters.Binary;
+using StackExchange.Redis;
 
 namespace CachingFramework.Redis.Serializers
 {
@@ -29,7 +30,7 @@ namespace CachingFramework.Redis.Serializers
         /// <typeparam name="T"></typeparam>
         /// <param name="value">The value.</param>
         /// <returns>System.String.</returns>
-        public virtual byte[] Serialize<T>(T value)
+        public virtual RedisValue Serialize<T>(T value)
         {
             return Serialize((object)value);
         }
@@ -39,7 +40,7 @@ namespace CachingFramework.Redis.Serializers
         /// <typeparam name="T"></typeparam>
         /// <param name="value">The value.</param>
         /// <returns>``0.</returns>
-        public virtual T Deserialize<T>(byte[] value)
+        public virtual T Deserialize<T>(RedisValue value)
         {
             return (T)Deserialize(value);
         }

--- a/src/CachingFramework.Redis/Serializers/JsonSerializer.cs
+++ b/src/CachingFramework.Redis/Serializers/JsonSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using Newtonsoft.Json;
+using StackExchange.Redis;
 
 namespace CachingFramework.Redis.Serializers
 {
@@ -36,9 +37,9 @@ namespace CachingFramework.Redis.Serializers
         /// <typeparam name="T"></typeparam>
         /// <param name="value">The value.</param>
         /// <returns>System.Byte[].</returns>
-        public byte[] Serialize<T>(T value)
+        public RedisValue Serialize<T>(T value)
         {
-            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(value, _settings));
+            return JsonConvert.SerializeObject(value, _settings);
         }
 
         /// <summary>
@@ -47,9 +48,9 @@ namespace CachingFramework.Redis.Serializers
         /// <typeparam name="T"></typeparam>
         /// <param name="value">The value.</param>
         /// <returns>T.</returns>
-        public T Deserialize<T>(byte[] value)
+        public T Deserialize<T>(RedisValue value)
         {
-            return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(value), _settings);
+            return JsonConvert.DeserializeObject<T>(value, _settings);
         }
     }
 }


### PR DESCRIPTION
improve serialization performance by prevent convert string to byte[] in JsonSerializer