### PR TITLE
Implement TryGetObjectAsync

### DIFF
--- a/src/CachingFramework.Redis/Contracts/Providers/ICacheProviderAsync.cs
+++ b/src/CachingFramework.Redis/Contracts/Providers/ICacheProviderAsync.cs
@@ -215,6 +215,16 @@ namespace CachingFramework.Redis.Contracts.Providers
         /// <returns>``0.</returns>
         Task<T> GetObjectAsync<T>(string key, CommandFlags flags = CommandFlags.None);
         /// <summary>
+        /// Try to get the value of a key
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <returns>
+        /// KeyExists is True if the cache contains an element with the specified key; otherwise, false.
+        /// Value is the value associated with the specified key, if the key is found; otherwise, the default value for the type T.
+        /// </returns>
+        Task<(bool keyExists, T value)> TryGetObjectAsync<T>(string key, CommandFlags flags = CommandFlags.None);
+        /// <summary>
         /// Gets all the keys related to the given tag(s).
         /// Returns a hashset with the keys.
         /// </summary>

--- a/src/CachingFramework.Redis/Providers/RedisCacheProvider.cs
+++ b/src/CachingFramework.Redis/Providers/RedisCacheProvider.cs
@@ -140,7 +140,16 @@ namespace CachingFramework.Redis.Providers
                 return Serializer.Deserialize<T>(cacheValue);
             }
             return default(T);
+        }
 
+        public async Task<(bool keyExists, T value)> TryGetObjectAsync<T>(string key, CommandFlags flags = CommandFlags.None)
+        {
+            var cacheValue = await RedisConnection.GetDatabase().StringGetAsync(key, flags).ForAwait();
+            if (cacheValue.HasValue)
+            {
+                return (true, Serializer.Deserialize<T>(cacheValue));
+            }
+            return (false, default(T));
         }
 
         public async Task<IEnumerable<string>> GetKeysByTagAsync(string[] tags, bool cleanUp = false)

--- a/test/CachingFramework.Redis.UnitTest/UnitTestRedis_Async.cs
+++ b/test/CachingFramework.Redis.UnitTest/UnitTestRedis_Async.cs
@@ -728,6 +728,31 @@ namespace CachingFramework.Redis.UnitTest
             await context.Cache.InvalidateKeysByTagAsync(tag);
         }
 
+        [Test, TestCaseSource(typeof(Common), "All")]
+        public async Task UT_CacheTryGetObject_Async(RedisContext context)
+        {
+            // Test the TryGetObject method
+            string key = "UT_CacheTryGetObject_Async";
+            context.Cache.Remove(key);
+            var expectedUser = new User()
+            {
+                Id = 1,
+                Deparments = new List<Department>()
+                {
+                    new Department() {Id = 1, Distance = 123.45m, Size = 2, Location = new Location { Id = 1, Name = "one" } },
+                    new Department() {Id = 2, Distance = 400, Size = 1, Location = new Location { Id = 2, Name = "two" } }
+                }
+            };
+            User cachedUser;
+            bool b;
+            await context.Cache.SetObjectAsync(key, expectedUser);
+            (b, cachedUser) = await context.Cache.TryGetObjectAsync<User>(key + "x7rz9a");
+            Assert.IsFalse(b);
+            Assert.IsNull(cachedUser);
+            (b, cachedUser) = await context.Cache.TryGetObjectAsync<User>(key);
+            Assert.IsTrue(b);
+            Assert.IsNotNull(cachedUser);
+        }
 
         [Test, TestCaseSource(typeof(Common), "All")]
         public async Task UT_CacheSetWithTags_Expiration_Async(RedisContext context)


### PR DESCRIPTION
There's a synchronous `TryGetObject` and an asynchronous `GetObjectAsync`, but there's no way to `TryGetObjectAsync`. I know that this is partially due to the more cumbersome method signature, but I still think there'd be value in having a `TryGetObjectAsync`.

The main use case for such a method existing is if you want to interact with the cache asynchronously, but may also store `null` in the cache for a particular key, which `GetObjectAsync` can't tell you.

I wrote a unit test but I can't seem to get the tests to run on my Macbook, so I don't actually know if it succeeds.

Please leave comments regarding style, documentation, method signature, etc. to make the suggested change fit well within the library.

If you don't feel that such a method belongs in the library, feel free to close the PR. 