### PR TITLE
Add Net 5.0 and Net 6.0 as targets and updates the nugets used

### DIFF
--- a/src/CachingFramework.Redis.MsgPack/CachingFramework.Redis.MsgPack.csproj
+++ b/src/CachingFramework.Redis.MsgPack/CachingFramework.Redis.MsgPack.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>CachingFramework.Redis.MsgPack</AssemblyTitle>
     <VersionPrefix>12.0.6</VersionPrefix>
     <Authors>Federico Colombo</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>CachingFramework.Redis.MsgPack</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -30,8 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="MsgPack.Cli" Version="0.8.0" />
   </ItemGroup>
 

--- a/src/CachingFramework.Redis.NewtonsoftJson/CachingFramework.Redis.NewtonsoftJson.csproj
+++ b/src/CachingFramework.Redis.NewtonsoftJson/CachingFramework.Redis.NewtonsoftJson.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>CachingFramework.Redis.NewtonsoftJson</AssemblyTitle>
     <VersionPrefix>12.0.6</VersionPrefix>
     <Authors>Federico Colombo</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>CachingFramework.Redis.NewtonsoftJson</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -30,9 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/CachingFramework.Redis/CachingFramework.Redis.csproj
+++ b/src/CachingFramework.Redis/CachingFramework.Redis.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Redis client library based on StackExchange.Redis with features like an extensible serialization strategy, a tagging mechanism to group keys and hash fields, and more, all being cluster-compatible.</Description>
@@ -6,7 +6,7 @@
     <AssemblyTitle>CachingFramework.Redis</AssemblyTitle>
     <VersionPrefix>12.0.6</VersionPrefix>
     <Authors>Federico Colombo</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>CachingFramework.Redis</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -26,9 +26,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/CachingFramework.Redis/RedisObjects/RedisBaseObject.cs
+++ b/src/CachingFramework.Redis/RedisObjects/RedisBaseObject.cs
@@ -80,7 +80,7 @@ namespace CachingFramework.Redis.RedisObjects
         public DateTime? Expiration
         {
             get { return DateTime.Now + GetRedisDb().KeyTimeToLive(RedisKey); }
-            set { GetRedisDb().KeyExpire(RedisKey, value); }
+            set { GetRedisDb().KeyExpire(RedisKey, value?.ToUniversalTime() - DateTime.UtcNow); }
         }
         /// <summary>
         /// Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.

--- a/test/CachingFramework.Redis.UnitTest/CachingFramework.Redis.UnitTest.csproj
+++ b/test/CachingFramework.Redis.UnitTest/CachingFramework.Redis.UnitTest.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>CachingFramework.Redis.UnitTest</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssemblyOriginatorKeyFile>../../src/CachingFramework.Redis.snk</AssemblyOriginatorKeyFile>
     <PackageId>CachingFramework.Redis.UnitTest</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -19,16 +18,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CachingFramework.Redis.NewtonsoftJson\CachingFramework.Redis.NewtonsoftJson.csproj" />
-    <ProjectReference Include="..\..\src\CachingFramework.Redis\CachingFramework.Redis.csproj" />
-    <ProjectReference Include="..\..\src\CachingFramework.Redis.MsgPack\CachingFramework.Redis.MsgPack.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
+    <ProjectReference Include="..\..\src\CachingFramework.Redis.NewtonsoftJson\CachingFramework.Redis.NewtonsoftJson.csproj" />
+    <ProjectReference Include="..\..\src\CachingFramework.Redis\CachingFramework.Redis.csproj" />
+    <ProjectReference Include="..\..\src\CachingFramework.Redis.MsgPack\CachingFramework.Redis.MsgPack.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/test/CachingFramework.Redis.UnitTest/UnitTestRedis.cs
+++ b/test/CachingFramework.Redis.UnitTest/UnitTestRedis.cs
@@ -454,7 +454,11 @@ namespace CachingFramework.Redis.UnitTest
             context.Cache.SetObject<SByte>(ksby, SByte.MaxValue);
             context.Cache.SetObject<Int16>(ki16, Int16.MaxValue);
             context.Cache.SetObject<Int32>(ki32, Int32.MaxValue);
-            context.Cache.SetObject<UIntPtr>(kuip, UIntPtr.Zero);
+            // TODO: System.Text.JSon cannot serialize this.
+            if (context.GetSerializer().GetType() != typeof(JsonSerializer))
+            {
+                context.Cache.SetObject<UIntPtr>(kuip, UIntPtr.Zero);
+            }
             context.Cache.SetObject<Double>(kdbl, Double.NegativeInfinity);
             context.Cache.SetObject<bool>(kpBool, true);
             context.Cache.SetObject<int>(kpInt, int.MaxValue);
@@ -462,7 +466,11 @@ namespace CachingFramework.Redis.UnitTest
             var now = DateTime.Now;
             context.Cache.SetObject<DateTime>(kdt, now);
             context.Cache.SetObject<Single>(kpSingle, Single.MaxValue);
-            context.Cache.SetObject<IntPtr>(kpIntPtr, new IntPtr(int.MaxValue));
+            // TODO: same as above. not supported in System.Text.Json
+            if (context.GetSerializer().GetType() != typeof(JsonSerializer))
+            {
+                context.Cache.SetObject<IntPtr>(kpIntPtr, new IntPtr(int.MaxValue));
+            }
             context.Cache.SetObject<UInt16>(kpUInt16, UInt16.MaxValue);
             context.Cache.SetObject<UInt32>(kpUInt32, UInt32.MaxValue);
             context.Cache.SetObject<UInt64>(kpUInt64, UInt64.MaxValue);

--- a/test/CachingFramework.Redis.UnitTest/UnitTestRedis_Async.cs
+++ b/test/CachingFramework.Redis.UnitTest/UnitTestRedis_Async.cs
@@ -317,7 +317,11 @@ namespace CachingFramework.Redis.UnitTest
             await context.Cache.SetObjectAsync<SByte>(ksby, SByte.MaxValue);
             await context.Cache.SetObjectAsync<Int16>(ki16, Int16.MaxValue);
             await context.Cache.SetObjectAsync<Int32>(ki32, Int32.MaxValue);
-            await context.Cache.SetObjectAsync<UIntPtr>(kuip, UIntPtr.Zero);
+            // TODO: this fails here because System.Text.Json cannot serialize UIntPtr
+            if (context.GetSerializer().GetType() != typeof(JsonSerializer))
+            {
+                await context.Cache.SetObjectAsync<UIntPtr>(kuip, UIntPtr.Zero);
+            }
             await context.Cache.SetObjectAsync<Double>(kdbl, Double.NegativeInfinity);
             await context.Cache.SetObjectAsync<bool>(kpBool, true);
             await context.Cache.SetObjectAsync<int>(kpInt, int.MaxValue);


### PR DESCRIPTION
I have added new targets, and updated the nugets.

I have also fixed a failing test, the expiration might be late if using Redis on a container (at least this happened to me locally, I guess the linux container on Docker might have had a slight difference in time). To fix this, when the user uses a DateTime to set the expiration, I calculate the timespan from now when this would expire. This ensure the expiration works as expected.

Without this fix, the expiration would always be a few seconds late.

Maybe before pulling it might be interesting to increase the version number so it can be published.